### PR TITLE
feat: option to hide the display of the main clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Chrome extension to add a timer onto the Wikiquiz scoring page and make passing order sticky
 
 ## Version History
+06.11.2022: v1.1.0 - Option to hide the display of the standard clock as it was confusing some players.
 05.11.2022: Make the timer settings customisable. Time can be set anywhere between 0 and 60 seconds.
 
 ## Instructions for installation

--- a/content.js
+++ b/content.js
@@ -106,16 +106,27 @@ const setButtonActions = () => {
   killButton.addEventListener("click", correctButtonHandler)
 }
 
+const hideClock = () => {
+  const $clock = $(".cell.w24.h7.ng-scope input");
+  $clock.css("color", "rgb(240, 240, 240)")
+}
+
 chrome.runtime.onMessage.addListener((request, _sender, _response) => {
   startTimeValue = request.startTimeValue
   passTimeValue = request.passTimeValue
+
+  removeClock = request.removeClock
 
   if ($("#timer-button").length == 0) {
     createNewButton("Start Timer")
   } else {
     console.log("Button already exists.")
   }
-  removeClockStickiness()
+  if(removeClock) {
+    hideClock()
+  } else {
+    removeClockStickiness()
+  }
   makePassingOrderSticky()
   setButtonActions()
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mimir Question Timer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Add an automatic timer button for Mimir quiz on Wikiquiz",
   "author": "Arnold D'Souza",
   "icons": {

--- a/popup.css
+++ b/popup.css
@@ -41,3 +41,7 @@ body {
 .error-message-hidden {
   display: none;
 }
+
+.checkbox-container {
+  margin-top: 10px;
+}

--- a/popup.html
+++ b/popup.html
@@ -16,6 +16,10 @@
     <label for="pass-duration" class="timer-label">PASS (0-60 sec):</label>
     <input type="number" name="pass-duration" value="5" class="timer-input" id="input-timer-pass" min="0" max="60" />
     <button class="submit-button" id="submit-button">SET TIMER</button>
+    <div class="checkbox-container">
+      <input type="checkbox" id="remove-clock" checked>
+      <label for="remove-clock">Remove the main clock</label>
+    </div>
     <p class="error-message error-message-hidden">Please enter the starting a value between 0-60 for starting and
       passing times</p>
   </div>

--- a/popup.js
+++ b/popup.js
@@ -14,7 +14,8 @@ submitButton.addEventListener("click", (e) => {
         chrome.tabs.sendMessage(tabs[0].id, {
           type: "CREATE_BUTTON",
           startTimeValue: startTime,
-          passTimeValue: passTime 
+          passTimeValue: passTime,
+          removeClock: document.getElementById("remove-clock").checked
         })
       }
       else {


### PR DESCRIPTION
1. Add a check box option in the `popup.html` to hide the display of the main clock as it was confusing some players.